### PR TITLE
Updated GitHub Labs link

### DIFF
--- a/courses/free-course-list.md
+++ b/courses/free-course-list.md
@@ -99,7 +99,7 @@
   </tr>
   <tr>
     <td>GitHub Learning Lab is an interactive guide to help developers master the art of using $ git and getting more familiar with GitHub by completing fun, realistic projects with the help of their friendly Learning Lab bot. Their goal is to help new developers retain more information and ramp up quickly as they start their journey on sofware development.</td>
-    <td align="center"><a href="https://lab.github.com/">View</a></td>
+    <td align="center"><a href="https://skills.github.com/">View</a></td>
   </tr>
 </table>
 


### PR DESCRIPTION
## Related Issue 

- Info about the related issue 

Closes: #41 

### Describe the changes you've made
The website of GitHub Labs is updated to https://skills.github.com/ in the doc it is not mentioned precisely.

## Type of change

What sort of change have you made:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

The website of GitHub Labs is updated to https://skills.github.com/ in the doc it is not mentioned precisely. Formerly, the link was https://loab.github.com which will eventually redirect to the change.

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly whereever it was hard to understand.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Screenshots

 Original           | Updated
 :--------------------: |:--------------------:
 original screenshot | updated screenshot |
